### PR TITLE
Do not check the return code on read timeout for bash 4.0+

### DIFF
--- a/now.sh
+++ b/now.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
-#
-#  See what 'read -t' returns on timeout.
-#
-#  For that - read from stdout. Alternatively, it could read
-#  from /dev/zero, but it's not available under Cygwin and
-#  in other non-*nix environments.
-#
-#  Also note, that while bash manual states that the return
-#  code on a timeout is greater than 128, it doesn't hold
-#  true with a number of bash implementations, most notably
-#  including GNU bash that returns 1 instead.
-#
-read -t 1 <&1
-timeout=$?
+if [ ${BASH_VERSINFO[0]} -ge 4 ]; then
+	#
+	# The return value of the read command is 128+SIGALRM
+	# if the timeout is exceeded.
+	#
+	timeout_rc=128
+	timeout_exp=-le
+else
+	#
+	#  See what 'read -t' returns on timeout.
+	#
+	#  For that - read from stdout. Alternatively, it could read
+	#  from /dev/zero, but it's not available under Cygwin and
+	#  in other non-*nix environments.
+	#
+	read -t 1 <&1
+	timeout_rc=$?
+	timeout_exp=-ne
+fi
 
 #
 #	loop forever
@@ -29,10 +34,7 @@ do
                 if [ $rc != 0 ]; then break; fi
                 echo "$line"
         done
-	#
-	#	exit status is greater than 128 if the timeout is exceeded
-	#
-	if [ $rc != $timeout ]; then break; fi
+	if [ $rc $timeout_exp $timeout_rc ]; then break; fi
 
 	#
 	#	print the timestamp


### PR DESCRIPTION
Is this patch OK?
